### PR TITLE
[bug fix] EASTL issue - function compare string with string_view cause random linker error (LINK1179)

### DIFF
--- a/src/core/src/sge_core/base/sge_base.h
+++ b/src/core/src/sge_core/base/sge_base.h
@@ -194,6 +194,15 @@ public:
 
 	template<class R> void operator+=(const R& r) { Base::operator+=(r); }
 
+	bool operator==(const typename Base::value_type* v) const { return Base::compare(v) == 0; }
+	bool operator!=(const typename Base::value_type* v) const { return !this->operator==(v); }
+	
+	bool operator==(StrViewT<T> v) const { return Base::compare(v.data()) == 0; }
+	bool operator!=(StrViewT<T> v) const { return !this->operator==(v); }
+	
+	template<size_t N> bool operator==(const StringT<T, N>& v) const { return Base::compare(v) == 0; }
+	template<size_t N> bool operator!=(const StringT<T, N>& v) const { return !this->operator==(v); }
+
 	StrViewT<T>	view() const { return StrViewT<T>(data(), size()); }
 };
 


### PR DESCRIPTION
## Issue Details

**Example code as following:**
```cpp
// sge_editor_app.cpp
class MainWin : public NativeUIWindow {
    using Base = NativeUIWindow;
public:
    void onCreate(CreateDesc& desc) {
        Base::onCreate(desc);
        auto* renderer = Renderer::instance();

        { // create render context
            RenderContext::CreateDesc renderContextDesc;
            renderContextDesc.window = this;
            _renderContext = renderer->createContext(renderContextDesc);
        }
        _material = renderer->createMaterial();
    }

    virtual void onDraw() {
        Base::onDraw();
        if (!_renderContext) return;
        //_material->setParam("test_float", 0.5f); // enable this comment will pass linker.
        drawNeeded();
    }

    SPtr<Material>        _material;
    SPtr<RenderContext>    _renderContext;
};
```
After compiled, it come up with linker error
7> sge_render.lib(unity_0_cxx.obj) : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT '??$?8D@eastl@@YA_NV?$basic_string_view@D@0@0@Z'

Linker error my screenshot
![图片](https://github.com/user-attachments/assets/6edf77f1-7516-421c-ad55-becf67e82027)
----------

**Simple work around as following:**
``` cpp
// ShaderInfo.h
        const Variable* findVariable(StrView propName) const {
            for (auto& v : variables) {
                //if (v.name == propName) return &v;
                if (v.name.compare(propName.data()) == 0) return &v; // use compare instead of operator==
            }
            return nullptr;
        }
```

----------
And What my pull request is 
override StringT  operator==, operator!= that  support function compare string and string_view!!